### PR TITLE
Feature/share recipe

### DIFF
--- a/Source/GroceryGuru.py
+++ b/Source/GroceryGuru.py
@@ -29,6 +29,7 @@ from database import (
 	create_friend_request, accept_friend_request, decline_friend_request, unfriend,
 	update_person_profile,
 	share_recipe_with_friends, add_shared_recipe_to_user,
+	dismiss_notification,
 )
 import recipe_extractor
 
@@ -1005,6 +1006,20 @@ def notifications():
 	return render_template("Notifications.j2", pending_requests=pending, recipe_shares=recipe_shares)
 
 
+@app.route("/Notifications/Dismiss", methods=["POST"])
+@login_required
+def dismiss_notification_route():
+	"""Dismiss a notification. Expects notification_type and notification_id in form."""
+	notification_type = request.form.get("notification_type", "").strip().lower()
+	notification_id = request.form.get("notification_id", type=int)
+	if not notification_type or notification_id is None:
+		return redirect(url_for("notifications"))
+	if notification_type not in ("friend_request", "recipe_share"):
+		return redirect(url_for("notifications"))
+	dismiss_notification(current_user.id, notification_type, notification_id)
+	return redirect(url_for("notifications"))
+
+
 @app.route("/Recipe/Shared/<int:share_id>", methods=["GET", "POST"])
 @login_required
 def shared_recipe_detail(share_id: int):
@@ -1014,6 +1029,8 @@ def shared_recipe_detail(share_id: int):
 		return "Shared recipe not found or you don't have access to it.", 404
 	share, recipe, sharer = row
 	recipe_id = recipe.id
+	# Dismiss the notification when user views the shared recipe
+	dismiss_notification(current_user.id, "recipe_share", share_id)
 	if request.method == "POST" and request.form.get("action") == "add":
 		new_id = add_shared_recipe_to_user(share_id, current_user.id)
 		if new_id:

--- a/Source/GroceryGuru.py
+++ b/Source/GroceryGuru.py
@@ -28,6 +28,7 @@ from database import (
 	upsert_recipe_rating, create_recipe_comment, create_recipe_image, delete_recipe_image,
 	create_friend_request, accept_friend_request, decline_friend_request, unfriend,
 	update_person_profile,
+	share_recipe_with_friends, add_shared_recipe_to_user,
 )
 import recipe_extractor
 
@@ -47,11 +48,17 @@ def inject_current_year():
 
 @app.context_processor
 def inject_notifications():
-	"""Inject pending friend request count and list for bell icon (logged-in users only)."""
+	"""Inject pending friend request count, recipe shares, and total for bell icon (logged-in users only)."""
 	if current_user.is_authenticated:
 		pending = database.Select.get_pending_friend_requests_for_user(current_user.id)
-		return {"notification_count": len(pending), "pending_friend_requests": pending}
-	return {"notification_count": 0, "pending_friend_requests": []}
+		recipe_shares = database.Select.get_recipe_shares_for_recipient(current_user.id)
+		total = len(pending) + len(recipe_shares)
+		return {
+			"notification_count": total,
+			"pending_friend_requests": pending,
+			"recipe_share_notifications": recipe_shares,
+		}
+	return {"notification_count": 0, "pending_friend_requests": [], "recipe_share_notifications": []}
 
 
 @app.context_processor
@@ -844,6 +851,7 @@ def recipe_detail(recipe_id: int):
 	recipe_images_data = [{"url": url_for("static", filename=img.file_path), "id": img.id} for img in recipe_images]
 	if not recipe_images_data and getattr(recipe, "image_url", None):
 		recipe_images_data = [{"url": recipe.image_url, "id": None}]
+	friends = database.Select.get_friends(current_user.id)
 	return render_template(
 		"Recipe.j2",
 		recipe=recipe,
@@ -855,8 +863,32 @@ def recipe_detail(recipe_id: int):
 		user_rating=user_rating,
 		comments=comments,
 		recipe_images_data=recipe_images_data,
+		friends=friends,
 		current_page="recipes",
 	)
+
+
+@app.route("/Recipe/<int:recipe_id>/share", methods=["POST"])
+@login_required
+def share_recipe(recipe_id: int):
+	"""Share a recipe with selected friends. Expects JSON: {"recipient_ids": [1, 2, ...]}."""
+	recipe = database.Select.get_Recipe_by_id(recipe_id, current_user.id)
+	if recipe is None:
+		return jsonify({"success": False, "error": "Recipe not found"}), 404
+	data = request.get_json(silent=True) or {}
+	recipient_ids = data.get("recipient_ids", [])
+	if not isinstance(recipient_ids, list):
+		recipient_ids = []
+	recipient_ids = [int(x) for x in recipient_ids if str(x).isdigit()]
+	if not recipient_ids:
+		return jsonify({"success": False, "error": "Select at least one friend"}), 400
+	success_count, errors = share_recipe_with_friends(recipe_id, current_user.id, recipient_ids)
+	if success_count == 0:
+		return jsonify({"success": False, "error": "; ".join(errors) if errors else "Could not share"}), 400
+	msg = f"Recipe shared with {success_count} friend{'s' if success_count != 1 else ''}."
+	if errors:
+		msg += " " + "; ".join(errors[:3])
+	return jsonify({"success": True, "message": msg, "shared_count": success_count})
 
 
 @app.route("/Recipe/<int:recipe_id>/delete-image/<int:image_id>", methods=["POST"])
@@ -967,9 +999,44 @@ def unfriend_route(friend_id: int):
 @app.route("/Friends/Notifications")
 @login_required
 def notifications():
-	"""Notifications page: pending friend requests (bell content)."""
+	"""Notifications page: pending friend requests and recipe shares."""
 	pending = database.Select.get_pending_friend_requests_for_user(current_user.id)
-	return render_template("Notifications.j2", pending_requests=pending)
+	recipe_shares = database.Select.get_recipe_shares_for_recipient(current_user.id)
+	return render_template("Notifications.j2", pending_requests=pending, recipe_shares=recipe_shares)
+
+
+@app.route("/Recipe/Shared/<int:share_id>", methods=["GET", "POST"])
+@login_required
+def shared_recipe_detail(share_id: int):
+	"""View a recipe shared with the current user. POST with action=add copies to their recipes."""
+	row = database.Select.get_recipe_share_by_id(share_id, current_user.id)
+	if row is None:
+		return "Shared recipe not found or you don't have access to it.", 404
+	share, recipe, sharer = row
+	recipe_id = recipe.id
+	if request.method == "POST" and request.form.get("action") == "add":
+		new_id = add_shared_recipe_to_user(share_id, current_user.id)
+		if new_id:
+			flash(f"Recipe added to your collection!", "success")
+			return redirect(url_for("recipe_detail", recipe_id=new_id))
+		else:
+			flash("Could not add recipe.", "error")
+	ingredients_list = [ln.strip() for ln in (recipe.ingredients or "").splitlines() if ln.strip()]
+	steps_list = [ln.strip() for ln in (recipe.steps or "").splitlines() if ln.strip()]
+	recipe_images = database.Select.get_recipe_images(recipe_id)
+	recipe_images_data = [{"url": url_for("static", filename=img.file_path), "id": img.id} for img in recipe_images]
+	if not recipe_images_data and getattr(recipe, "image_url", None):
+		recipe_images_data = [{"url": recipe.image_url, "id": None}]
+	return render_template(
+		"SharedRecipe.j2",
+		share=share,
+		recipe=recipe,
+		sharer=sharer,
+		ingredients_list=ingredients_list,
+		steps_list=steps_list,
+		recipe_images_data=recipe_images_data,
+		current_page="recipes",
+	)
 
 
 if __name__ == "__main__":

--- a/Source/database/Select.py
+++ b/Source/database/Select.py
@@ -183,15 +183,25 @@ def get_Person_by_email(email: str):
 
 
 def get_pending_friend_requests_for_user(addressee_id: int):
-	"""Return pending FriendRequests where addressee_id is the user. Each row has requester info."""
-	from database import engine, FriendRequests, Persons
+	"""Return pending FriendRequests where addressee_id is the user, excluding dismissed. Each row has requester info."""
+	from database import engine, FriendRequests, Persons, DismissedNotifications
 	with Session(engine) as session:
-		rows = session.query(FriendRequests, Persons).join(
+		dismissed_ids = {
+			row[0]
+			for row in session.query(DismissedNotifications.notification_id).filter(
+				DismissedNotifications.user_id == addressee_id,
+				DismissedNotifications.notification_type == "friend_request",
+			).all()
+		}
+		query = session.query(FriendRequests, Persons).join(
 			Persons, FriendRequests.requester_id == Persons.id,
 		).filter(
 			FriendRequests.addressee_id == addressee_id,
 			FriendRequests.status == "pending",
-		).order_by(FriendRequests.created_at.desc()).all()
+		)
+		if dismissed_ids:
+			query = query.filter(FriendRequests.id.notin_(dismissed_ids))
+		rows = query.order_by(FriendRequests.created_at.desc()).all()
 		return rows
 
 
@@ -237,17 +247,27 @@ def get_friend_request_by_id(request_id: int, addressee_id: int):
 # ————————————————————————————————— Recipe shares ———————————————————————————————— #
 
 def get_recipe_shares_for_recipient(recipient_id: int):
-	"""Return (RecipeShares, Recipes, Persons) for shares received by user, newest first."""
-	from database import engine, RecipeShares, Recipes, Persons
+	"""Return (RecipeShares, Recipes, Persons) for shares received by user, excluding dismissed, newest first."""
+	from database import engine, RecipeShares, Recipes, Persons, DismissedNotifications
 	with Session(engine) as session:
-		return session.query(RecipeShares, Recipes, Persons).join(
+		dismissed_ids = {
+			row[0]
+			for row in session.query(DismissedNotifications.notification_id).filter(
+				DismissedNotifications.user_id == recipient_id,
+				DismissedNotifications.notification_type == "recipe_share",
+			).all()
+		}
+		query = session.query(RecipeShares, Recipes, Persons).join(
 			Recipes, getattr(RecipeShares, "Recipes.id") == Recipes.id,
 		).join(
 			Persons, RecipeShares.sharer_id == Persons.id,
 		).filter(
 			RecipeShares.recipient_id == recipient_id,
 			Recipes.is_deleted == False,
-		).order_by(RecipeShares.created_at.desc()).all()
+		)
+		if dismissed_ids:
+			query = query.filter(RecipeShares.id.notin_(dismissed_ids))
+		return query.order_by(RecipeShares.created_at.desc()).all()
 
 
 def get_recipe_share_by_id(share_id: int, recipient_id: int):

--- a/Source/database/Select.py
+++ b/Source/database/Select.py
@@ -232,3 +232,34 @@ def get_friend_request_by_id(request_id: int, addressee_id: int):
 			FriendRequests.addressee_id == addressee_id,
 			FriendRequests.status == "pending",
 		).first()
+
+
+# ————————————————————————————————— Recipe shares ———————————————————————————————— #
+
+def get_recipe_shares_for_recipient(recipient_id: int):
+	"""Return (RecipeShares, Recipes, Persons) for shares received by user, newest first."""
+	from database import engine, RecipeShares, Recipes, Persons
+	with Session(engine) as session:
+		return session.query(RecipeShares, Recipes, Persons).join(
+			Recipes, getattr(RecipeShares, "Recipes.id") == Recipes.id,
+		).join(
+			Persons, RecipeShares.sharer_id == Persons.id,
+		).filter(
+			RecipeShares.recipient_id == recipient_id,
+			Recipes.is_deleted == False,
+		).order_by(RecipeShares.created_at.desc()).all()
+
+
+def get_recipe_share_by_id(share_id: int, recipient_id: int):
+	"""Return (RecipeShares, Recipes, Persons) for a share if recipient matches, else None."""
+	from database import engine, RecipeShares, Recipes, Persons
+	with Session(engine) as session:
+		return session.query(RecipeShares, Recipes, Persons).join(
+			Recipes, getattr(RecipeShares, "Recipes.id") == Recipes.id,
+		).join(
+			Persons, RecipeShares.sharer_id == Persons.id,
+		).filter(
+			RecipeShares.id == share_id,
+			RecipeShares.recipient_id == recipient_id,
+			Recipes.is_deleted == False,
+		).first()

--- a/Source/database/__init__.py
+++ b/Source/database/__init__.py
@@ -191,6 +191,27 @@ def _migrate_recipe_shares_if_needed():
 			""")
 
 
+def _migrate_dismissed_notifications_if_needed():
+	"""Create DismissedNotifications table for tracking dismissed notifications."""
+	import sqlite3
+	if not Path(_db_path).exists():
+		return
+	with sqlite3.connect(_db_path) as raw:
+		cur = raw.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='DismissedNotifications'")
+		if cur.fetchone() is None:
+			raw.execute("""
+				CREATE TABLE "DismissedNotifications" (
+					"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+					"user_id" INTEGER NOT NULL,
+					"notification_type" TEXT NOT NULL,
+					"notification_id" INTEGER NOT NULL,
+					"dismissed_at" TEXT NOT NULL DEFAULT (datetime('now')),
+					UNIQUE ("user_id", "notification_type", "notification_id"),
+					FOREIGN KEY ("user_id") REFERENCES "Persons"("id")
+				)
+			""")
+
+
 _init_schema_if_needed()
 _migrate_add_notes_if_needed()
 _migrate_recipes_table_if_needed()
@@ -200,6 +221,7 @@ _migrate_recipe_comments_if_needed()
 _migrate_recipe_images_if_needed()
 _migrate_friend_requests_if_needed()
 _migrate_recipe_shares_if_needed()
+_migrate_dismissed_notifications_if_needed()
 
 # reflect the tables
 Base = automap_base()
@@ -219,6 +241,7 @@ RecipeComments = Base.classes.RecipeComments
 RecipeImages = Base.classes.RecipeImages
 FriendRequests = Base.classes.FriendRequests
 RecipeShares = Base.classes.RecipeShares
+DismissedNotifications = Base.classes.DismissedNotifications
 
 
 def get_user_count():
@@ -706,6 +729,29 @@ def share_recipe_with_friends(recipe_id: int, sharer_id: int, recipient_ids: lis
 		except ValueError as e:
 			errors.append(str(e))
 	return success, errors
+
+
+def dismiss_notification(user_id: int, notification_type: str, notification_id: int) -> bool:
+	"""Mark a notification as dismissed. Returns True if recorded (or already dismissed)."""
+	notification_type = (notification_type or "").strip().lower()
+	if notification_type not in ("friend_request", "recipe_share"):
+		return False
+	with Session(engine) as session:
+		existing = session.query(DismissedNotifications).filter(
+			DismissedNotifications.user_id == user_id,
+			DismissedNotifications.notification_type == notification_type,
+			DismissedNotifications.notification_id == notification_id,
+		).first()
+		if existing:
+			return True
+		stmt = insert(DismissedNotifications.__table__).values(**{
+			"user_id": user_id,
+			"notification_type": notification_type,
+			"notification_id": notification_id,
+		})
+		session.execute(stmt)
+		session.commit()
+	return True
 
 
 def add_shared_recipe_to_user(share_id: int, recipient_id: int) -> int | None:

--- a/Source/database/__init__.py
+++ b/Source/database/__init__.py
@@ -169,6 +169,28 @@ def _migrate_friend_requests_if_needed():
 			""")
 
 
+def _migrate_recipe_shares_if_needed():
+	"""Create RecipeShares table for recipe sharing between friends."""
+	import sqlite3
+	if not Path(_db_path).exists():
+		return
+	with sqlite3.connect(_db_path) as raw:
+		cur = raw.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='RecipeShares'")
+		if cur.fetchone() is None:
+			raw.execute("""
+				CREATE TABLE "RecipeShares" (
+					"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+					"Recipes.id" INTEGER NOT NULL,
+					"sharer_id" INTEGER NOT NULL,
+					"recipient_id" INTEGER NOT NULL,
+					"created_at" TEXT NOT NULL DEFAULT (datetime('now')),
+					FOREIGN KEY ("Recipes.id") REFERENCES "Recipes"("id"),
+					FOREIGN KEY ("sharer_id") REFERENCES "Persons"("id"),
+					FOREIGN KEY ("recipient_id") REFERENCES "Persons"("id")
+				)
+			""")
+
+
 _init_schema_if_needed()
 _migrate_add_notes_if_needed()
 _migrate_recipes_table_if_needed()
@@ -177,6 +199,7 @@ _migrate_recipe_ratings_if_needed()
 _migrate_recipe_comments_if_needed()
 _migrate_recipe_images_if_needed()
 _migrate_friend_requests_if_needed()
+_migrate_recipe_shares_if_needed()
 
 # reflect the tables
 Base = automap_base()
@@ -195,6 +218,7 @@ RecipeRatings = Base.classes.RecipeRatings
 RecipeComments = Base.classes.RecipeComments
 RecipeImages = Base.classes.RecipeImages
 FriendRequests = Base.classes.FriendRequests
+RecipeShares = Base.classes.RecipeShares
 
 
 def get_user_count():
@@ -634,6 +658,90 @@ def unfriend(user_id: int, friend_id: int) -> bool:
 		session.execute(sql_delete(FriendRequests.__table__).where(FriendRequests.__table__.c.id == row.id))
 		session.commit()
 		return True
+
+
+# ————————————————————————————————— Recipe sharing ———————————————————————————————— #
+
+def create_recipe_share(recipe_id: int, sharer_id: int, recipient_id: int) -> int:
+	"""Create a recipe share. Returns share id. Raises ValueError if invalid."""
+	if sharer_id == recipient_id:
+		raise ValueError("You cannot share a recipe with yourself.")
+	with Session(engine) as session:
+		# Check recipe exists and belongs to sharer
+		recipe = session.query(Recipes).filter(
+			Recipes.id == recipe_id,
+			getattr(Recipes, "Persons.id") == sharer_id,
+			Recipes.is_deleted == False,
+		).first()
+		if not recipe:
+			raise ValueError("Recipe not found.")
+		# Check not already shared with this recipient
+		existing = session.query(RecipeShares).filter(
+			getattr(RecipeShares, "Recipes.id") == recipe_id,
+			RecipeShares.sharer_id == sharer_id,
+			RecipeShares.recipient_id == recipient_id,
+		).first()
+		if existing:
+			raise ValueError("Recipe already shared with this friend.")
+		stmt = insert(RecipeShares.__table__).values(**{
+			"Recipes.id": recipe_id,
+			"sharer_id": sharer_id,
+			"recipient_id": recipient_id,
+		})
+		result = session.execute(stmt)
+		session.commit()
+		return result.inserted_primary_key[0]
+
+
+def share_recipe_with_friends(recipe_id: int, sharer_id: int, recipient_ids: list[int]) -> tuple[int, list[str]]:
+	"""Share recipe with multiple friends. Returns (success_count, list of error messages)."""
+	success = 0
+	errors = []
+	for rid in recipient_ids:
+		if rid == sharer_id:
+			continue
+		try:
+			create_recipe_share(recipe_id, sharer_id, rid)
+			success += 1
+		except ValueError as e:
+			errors.append(str(e))
+	return success, errors
+
+
+def add_shared_recipe_to_user(share_id: int, recipient_id: int) -> int | None:
+	"""Copy the shared recipe to the recipient's recipes. Returns new recipe id or None if invalid."""
+	with Session(engine) as session:
+		share = session.query(RecipeShares).filter(
+			RecipeShares.id == share_id,
+			RecipeShares.recipient_id == recipient_id,
+		).first()
+		if not share:
+			return None
+		recipe_id = getattr(share, "Recipes.id")
+		recipe = session.query(Recipes).filter(
+			Recipes.id == recipe_id,
+			Recipes.is_deleted == False,
+		).first()
+		if not recipe:
+			return None
+		# Create copy for recipient
+		new_id = create_recipe(
+			title=recipe.title,
+			Persons_id=recipient_id,
+			ingredients=recipe.ingredients or "",
+			steps=recipe.steps or "",
+			special_notes=recipe.special_notes or None,
+			source_url=recipe.source_url or None,
+			category=recipe.category or None,
+			image_url=getattr(recipe, "image_url", None) or None,
+		)
+		# Copy RecipeImages
+		images = session.query(RecipeImages).filter(
+			getattr(RecipeImages, "Recipes.id") == recipe_id,
+		).order_by(RecipeImages.sort_order).all()
+		for i, img in enumerate(images):
+			create_recipe_image(new_id, img.file_path)
+		return new_id
 
 
 def update_person_profile(person_id: int, name: str = None, email: str = None) -> bool:

--- a/Source/static/css/Style.css
+++ b/Source/static/css/Style.css
@@ -1348,3 +1348,91 @@ a:hover {
 	color: var(--error);
 	border: 1px solid var(--error);
 }
+
+/* --- Share recipe modal --- */
+.share-modal {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 1.5rem;
+}
+
+.share-modal-overlay {
+	position: absolute;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+}
+
+.share-modal-content {
+	position: relative;
+	background: var(--bg-secondary);
+	border-radius: 12px;
+	box-shadow: var(--shadow-lg);
+	padding: 1.5rem;
+	max-width: 400px;
+	width: 100%;
+	max-height: 80vh;
+	overflow-y: auto;
+}
+
+.share-modal-content h2 {
+	margin: 0 0 1rem 0;
+	font-size: 1.25rem;
+}
+
+.share-friends-list {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 1rem 0;
+	max-height: 240px;
+	overflow-y: auto;
+}
+
+.share-friend-item {
+	margin-bottom: 0.25rem;
+}
+
+.share-friend-label {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	border-radius: 8px;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.share-friend-label:hover {
+	background: var(--accent-bg);
+}
+
+.share-friend-checkbox {
+	margin: 0;
+}
+
+.share-friend-name {
+	font-weight: 500;
+}
+
+.share-friend-email {
+	font-size: 0.875rem;
+}
+
+.share-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	padding-top: 1rem;
+	border-top: 1px solid var(--border);
+}
+
+.shared-by-banner {
+	background: var(--accent-bg);
+	padding: 0.75rem 1rem;
+	border-radius: 8px;
+	margin: 0 0 1rem 0;
+	border: 1px solid var(--border);
+}

--- a/Source/static/css/Style.css
+++ b/Source/static/css/Style.css
@@ -1429,10 +1429,40 @@ a:hover {
 	border-top: 1px solid var(--border);
 }
 
-.shared-by-banner {
+.shared-by-tag {
+	margin: -0.25rem 0 1rem 0;
+	font-size: 0.95rem;
+	color: var(--text-muted);
+}
+
+.shared-by-tag strong {
+	color: var(--text-secondary);
+}
+
+.notification-item {
+	position: relative;
+	padding-right: 2.5rem;
+}
+
+.notification-dismiss-form {
+	position: absolute;
+	top: 0.5rem;
+	right: 0.5rem;
+}
+
+.notification-dismiss-btn {
+	background: transparent;
+	border: none;
+	color: var(--text-muted);
+	font-size: 1.5rem;
+	line-height: 1;
+	padding: 0.25rem 0.5rem;
+	cursor: pointer;
+	border-radius: 4px;
+	transition: color 0.15s, background 0.15s;
+}
+
+.notification-dismiss-btn:hover {
+	color: var(--text-primary);
 	background: var(--accent-bg);
-	padding: 0.75rem 1rem;
-	border-radius: 8px;
-	margin: 0 0 1rem 0;
-	border: 1px solid var(--border);
 }

--- a/Source/templates/Notifications.j2
+++ b/Source/templates/Notifications.j2
@@ -5,7 +5,7 @@
 {% block content %}
 	<div class="card">
 		<h1>Notifications</h1>
-		<p class="text-muted">Friend requests and activity.</p>
+		<p class="text-muted">Friend requests and shared recipes.</p>
 
 		<h2>Friend requests</h2>
 		{% if pending_requests %}
@@ -29,6 +29,24 @@
 			</ul>
 		{% else %}
 			<p class="text-muted">No pending friend requests.</p>
+		{% endif %}
+
+		<h2 style="margin-top: 2rem;">Shared recipes</h2>
+		{% if recipe_shares %}
+			<ul class="notifications-list">
+				{% for share, recipe, sharer in recipe_shares %}
+					<li class="notification-item">
+						<div class="notification-content">
+							<p><strong>{{ sharer.name | default(sharer.email) }}</strong> shared a recipe! <strong>{{ recipe.title }}</strong></p>
+						</div>
+						<div class="notification-actions">
+							<a href="{{ url_for('shared_recipe_detail', share_id=share.id) }}" class="btn btn-primary btn-sm">View recipe</a>
+						</div>
+					</li>
+				{% endfor %}
+			</ul>
+		{% else %}
+			<p class="text-muted">No shared recipes.</p>
 		{% endif %}
 	</div>
 {% endblock %}

--- a/Source/templates/Notifications.j2
+++ b/Source/templates/Notifications.j2
@@ -12,6 +12,11 @@
 			<ul class="notifications-list">
 				{% for fr, requester in pending_requests %}
 					<li class="notification-item">
+						<form method="POST" action="{{ url_for('dismiss_notification_route') }}" class="notification-dismiss-form">
+							<input type="hidden" name="notification_type" value="friend_request">
+							<input type="hidden" name="notification_id" value="{{ fr.id }}">
+							<button type="submit" class="notification-dismiss-btn" aria-label="Dismiss">×</button>
+						</form>
 						<div class="notification-content">
 							<p><strong>{{ requester.name | default(requester.email) }}</strong> ({{ requester.email }}) wants to be your friend.</p>
 							{% if fr.message %}<p class="notification-message text-muted">{{ fr.message }}</p>{% endif %}
@@ -36,6 +41,11 @@
 			<ul class="notifications-list">
 				{% for share, recipe, sharer in recipe_shares %}
 					<li class="notification-item">
+						<form method="POST" action="{{ url_for('dismiss_notification_route') }}" class="notification-dismiss-form">
+							<input type="hidden" name="notification_type" value="recipe_share">
+							<input type="hidden" name="notification_id" value="{{ share.id }}">
+							<button type="submit" class="notification-dismiss-btn" aria-label="Dismiss">×</button>
+						</form>
 						<div class="notification-content">
 							<p><strong>{{ sharer.name | default(sharer.email) }}</strong> shared a recipe! <strong>{{ recipe.title }}</strong></p>
 						</div>

--- a/Source/templates/Recipe.j2
+++ b/Source/templates/Recipe.j2
@@ -61,8 +61,36 @@
 			</form>
 		</div>
 
-		<div id="recipe-view-actions" style="margin-bottom: 1rem;">
+		<div id="recipe-view-actions" style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
 			<button type="button" id="btn-edit-recipe" class="btn btn-primary">Edit</button>
+			<button type="button" id="btn-share-recipe" class="btn btn-outline">Share</button>
+		</div>
+
+		<!-- Share recipe modal -->
+		<div id="share-recipe-modal" class="share-modal" role="dialog" aria-modal="true" aria-labelledby="share-modal-title" style="display: none;">
+			<div class="share-modal-overlay" id="share-modal-overlay"></div>
+			<div class="share-modal-content">
+				<h2 id="share-modal-title">Share recipe with friends</h2>
+				{% if friends %}
+					<ul class="share-friends-list">
+						{% for friend in friends %}
+							<li class="share-friend-item">
+								<label class="share-friend-label">
+									<input type="checkbox" class="share-friend-checkbox" value="{{ friend.id }}" name="share_friend">
+									<span class="share-friend-name">{{ friend.name or friend.email }}</span>
+									{% if friend.email %}<span class="share-friend-email text-muted">({{ friend.email }})</span>{% endif %}
+								</label>
+							</li>
+						{% endfor %}
+					</ul>
+				{% else %}
+					<p class="text-muted">You don't have any friends yet. <a href="{{ url_for('add_friend') }}">Add a friend</a> to share recipes with them.</p>
+				{% endif %}
+				<div class="share-modal-actions">
+					<button type="button" id="share-modal-cancel" class="btn btn-secondary">Cancel</button>
+					<button type="button" id="share-modal-send" class="btn btn-primary" {% if not friends %}disabled{% endif %}>Send</button>
+				</div>
+			</div>
 		</div>
 
 		<div id="recipe-view" class="recipe-profile-view">
@@ -386,6 +414,46 @@
 			return false;
 		}
 		form.addEventListener('submit', onFormSubmit);
+
+		// Share recipe modal
+		var shareModal = document.getElementById('share-recipe-modal');
+		var shareOverlay = document.getElementById('share-modal-overlay');
+		var btnShare = document.getElementById('btn-share-recipe');
+		var btnShareCancel = document.getElementById('share-modal-cancel');
+		var btnShareSend = document.getElementById('share-modal-send');
+		if (btnShare && shareModal) {
+			btnShare.addEventListener('click', function() {
+				shareModal.style.display = 'flex';
+				document.querySelectorAll('.share-friend-checkbox').forEach(function(cb) { cb.checked = false; });
+			});
+			function closeShareModal() {
+				shareModal.style.display = 'none';
+			}
+			if (shareOverlay) shareOverlay.addEventListener('click', closeShareModal);
+			if (btnShareCancel) btnShareCancel.addEventListener('click', closeShareModal);
+			if (btnShareSend) btnShareSend.addEventListener('click', function() {
+				var checked = document.querySelectorAll('.share-friend-checkbox:checked');
+				var ids = Array.prototype.map.call(checked, function(cb) { return parseInt(cb.value, 10); });
+				if (ids.length === 0) {
+					alert('Please select at least one friend.');
+					return;
+				}
+				btnShareSend.disabled = true;
+				fetch('/Recipe/' + recipeId + '/share', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ recipient_ids: ids }),
+					credentials: 'same-origin'
+				}).then(function(r) { return r.json(); }).then(function(data) {
+					closeShareModal();
+					alert(data.message || (data.success ? 'Recipe shared!' : data.error || 'Failed'));
+				}).catch(function() {
+					alert('Something went wrong.');
+				}).finally(function() {
+					btnShareSend.disabled = false;
+				});
+			});
+		}
 	})();
 	</script>
 {% endblock %}

--- a/Source/templates/SharedRecipe.j2
+++ b/Source/templates/SharedRecipe.j2
@@ -11,10 +11,6 @@
 			</p>
 		</div>
 
-		<p class="shared-by-banner">
-			<strong>{{ sharer.name or sharer.email }}</strong> shared this recipe with you.
-		</p>
-
 		<div id="recipe-images-wrapper" class="{% if not recipe_images_data %}recipe-images-empty{% endif %}">
 			<div class="recipe-image-carousel" id="recipe-image-carousel" {% if not recipe_images_data %}style="display: none;"{% endif %}>
 				<button type="button" class="recipe-carousel-arrow recipe-carousel-prev recipe-carousel-arrow-hide" id="recipe-carousel-prev" aria-label="Previous image">‹</button>
@@ -30,6 +26,7 @@
 		</div>
 
 		<h1>{{ recipe.title }}</h1>
+		<p class="shared-by-tag">Shared by <strong>{{ sharer.name or sharer.email }}</strong></p>
 
 		<div id="recipe-view" class="recipe-profile-view">
 			<p class="recipe-source">

--- a/Source/templates/SharedRecipe.j2
+++ b/Source/templates/SharedRecipe.j2
@@ -1,0 +1,158 @@
+{% extends "Base.j2" %}
+
+{% block title %}{{ recipe.title }} — Shared by {{ sharer.name or sharer.email }} — Grocery Guru{% endblock %}
+
+{% block content %}
+	<div class="card">
+		<div class="recipe-header-row">
+			<p class="recipe-breadcrumb" style="margin: 0;">
+				<a href="{{ url_for('recipes_index') }}">← Recipes</a>
+				| <a href="{{ url_for('notifications') }}">Notifications</a>
+			</p>
+		</div>
+
+		<p class="shared-by-banner">
+			<strong>{{ sharer.name or sharer.email }}</strong> shared this recipe with you.
+		</p>
+
+		<div id="recipe-images-wrapper" class="{% if not recipe_images_data %}recipe-images-empty{% endif %}">
+			<div class="recipe-image-carousel" id="recipe-image-carousel" {% if not recipe_images_data %}style="display: none;"{% endif %}>
+				<button type="button" class="recipe-carousel-arrow recipe-carousel-prev recipe-carousel-arrow-hide" id="recipe-carousel-prev" aria-label="Previous image">‹</button>
+				<div class="recipe-carousel-inner" id="recipe-carousel-inner">
+					{% for img in recipe_images_data %}
+						<div class="recipe-carousel-slide {% if loop.first %}active{% endif %}">
+							<img src="{{ img.url }}" alt="{{ recipe.title }}" class="recipe-carousel-img {% if loop.first %}active{% endif %}" data-index="{{ loop.index0 }}">
+						</div>
+					{% endfor %}
+				</div>
+				<button type="button" class="recipe-carousel-arrow recipe-carousel-next recipe-carousel-arrow-hide" id="recipe-carousel-next" aria-label="Next image">›</button>
+			</div>
+		</div>
+
+		<h1>{{ recipe.title }}</h1>
+
+		<div id="recipe-view" class="recipe-profile-view">
+			<p class="recipe-source">
+				<strong>Source:</strong>
+				{% if recipe.source_url %}
+					<a href="{{ recipe.source_url }}" target="_blank" rel="noopener noreferrer">{{ recipe.source_url }}</a>
+				{% else %}
+					<span class="text-muted">(none)</span>
+				{% endif %}
+			</p>
+			<div class="recipe-section">
+				<h3>Ingredients</h3>
+				<ul class="recipe-checklist" id="recipe-ingredients-list">
+					{% for line in ingredients_list %}
+					<li class="recipe-check-item">
+						<label class="recipe-check-label">
+							<input type="checkbox" class="recipe-checkbox" data-type="ingredients" data-index="{{ loop.index0 }}">
+							<span class="recipe-check-text">{{ line }}</span>
+						</label>
+					</li>
+					{% else %}
+					<li class="recipe-check-empty"><span class="text-muted">(none)</span></li>
+					{% endfor %}
+				</ul>
+			</div>
+			<div class="recipe-section">
+				<h3>Steps</h3>
+				<ul class="recipe-checklist" id="recipe-steps-list">
+					{% for line in steps_list %}
+					<li class="recipe-check-item">
+						<label class="recipe-check-label">
+							<input type="checkbox" class="recipe-checkbox" data-type="steps" data-index="{{ loop.index0 }}">
+							<span class="recipe-check-text">{{ line }}</span>
+						</label>
+					</li>
+					{% else %}
+					<li class="recipe-check-empty"><span class="text-muted">(none)</span></li>
+					{% endfor %}
+				</ul>
+			</div>
+			<div class="recipe-section">
+				<h3>Notes</h3>
+				<pre class="recipe-block">{{ recipe.special_notes or '(none)' }}</pre>
+			</div>
+		</div>
+
+		<div class="shared-recipe-actions" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
+			<form method="post" action="{{ url_for('shared_recipe_detail', share_id=share.id) }}">
+				<input type="hidden" name="action" value="add">
+				<button type="submit" class="btn btn-primary">Add to my recipes</button>
+			</form>
+		</div>
+	</div>
+	<script>
+	(function() {
+		var recipeId = {{ recipe.id }};
+		var storageKey = function(type) { return 'shared-recipe-' + recipeId + '-' + type; };
+
+		// Restore checkbox state from localStorage
+		function loadChecks(type) {
+			try {
+				var raw = localStorage.getItem(storageKey(type));
+				if (raw) {
+					var idx = JSON.parse(raw);
+					document.querySelectorAll('.recipe-checkbox[data-type="' + type + '"]').forEach(function(cb) {
+						cb.checked = idx.indexOf(parseInt(cb.dataset.index, 10)) >= 0;
+					});
+				}
+			} catch (e) {}
+		}
+		loadChecks('ingredients');
+		loadChecks('steps');
+
+		document.querySelectorAll('.recipe-checkbox').forEach(function(cb) {
+			cb.addEventListener('change', function() {
+				var type = this.dataset.type;
+				var checked = [];
+				document.querySelectorAll('.recipe-checkbox[data-type="' + type + '"]').forEach(function(c) {
+					if (c.checked) checked.push(parseInt(c.dataset.index, 10));
+				});
+				try { localStorage.setItem(storageKey(type), JSON.stringify(checked)); } catch (e) {}
+			});
+		});
+
+		var carousel = document.getElementById('recipe-image-carousel');
+		var carouselInner = document.getElementById('recipe-carousel-inner');
+		var prevBtn = document.getElementById('recipe-carousel-prev');
+		var nextBtn = document.getElementById('recipe-carousel-next');
+
+		function countSlides() { return (carouselInner && carouselInner.querySelectorAll('.recipe-carousel-slide').length) || 0; }
+		function updateArrows() {
+			var n = countSlides();
+			if (prevBtn && nextBtn) {
+				prevBtn.classList.toggle('recipe-carousel-arrow-hide', n < 2);
+				nextBtn.classList.toggle('recipe-carousel-arrow-hide', n < 2);
+			}
+		}
+		updateArrows();
+
+		function showSlide(i) {
+			var imgs = carousel && carousel.querySelectorAll('.recipe-carousel-img');
+			var slides = carousel && carousel.querySelectorAll('.recipe-carousel-slide');
+			if (!imgs || !imgs.length) return;
+			var n = imgs.length;
+			var idx = ((i % n) + n) % n;
+			imgs.forEach(function(img, j) { img.classList.toggle('active', j === idx); });
+			if (slides && slides.length) slides.forEach(function(slide, j) { slide.classList.toggle('active', j === idx); });
+			return idx;
+		}
+
+		var carouselIdx = 0;
+		if (carousel && prevBtn && nextBtn) {
+			prevBtn.addEventListener('click', function() {
+				var n = countSlides();
+				if (n < 2) return;
+				carouselIdx = showSlide(carouselIdx - 1);
+			});
+			nextBtn.addEventListener('click', function() {
+				var n = countSlides();
+				if (n < 2) return;
+				carouselIdx = showSlide(carouselIdx + 1);
+			});
+		}
+	})();
+	</script>
+{% endblock %}

--- a/Source/templates/SharedRecipe.j2
+++ b/Source/templates/SharedRecipe.j2
@@ -76,11 +76,12 @@
 			</div>
 		</div>
 
-		<div class="shared-recipe-actions" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
-			<form method="post" action="{{ url_for('shared_recipe_detail', share_id=share.id) }}">
+		<div class="shared-recipe-actions" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border); display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
+			<form method="post" action="{{ url_for('shared_recipe_detail', share_id=share.id) }}" style="display: inline;">
 				<input type="hidden" name="action" value="add">
 				<button type="submit" class="btn btn-primary">Add to my recipes</button>
 			</form>
+			<a href="{{ url_for('notifications') }}" class="btn btn-secondary">Exit without adding</a>
 		</div>
 	</div>
 	<script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,10 @@ def _clean_db_before_test(request):
 				conn.execute("DELETE FROM RecipeShares")
 			except sqlite3.OperationalError:
 				pass
+			try:
+				conn.execute("DELETE FROM DismissedNotifications")
+			except sqlite3.OperationalError:
+				pass
 			conn.execute("DELETE FROM Recipes")
 			conn.execute("DELETE FROM InventoryIngredients")
 			conn.execute("DELETE FROM ListIngredients")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,10 @@ def _clean_db_before_test(request):
 				conn.execute("DELETE FROM FriendRequests")
 			except sqlite3.OperationalError:
 				pass
+			try:
+				conn.execute("DELETE FROM RecipeShares")
+			except sqlite3.OperationalError:
+				pass
 			conn.execute("DELETE FROM Recipes")
 			conn.execute("DELETE FROM InventoryIngredients")
 			conn.execute("DELETE FROM ListIngredients")

--- a/tests/test_recipe_sharing.py
+++ b/tests/test_recipe_sharing.py
@@ -1,0 +1,439 @@
+"""Unit tests for the recipe sharing feature: share with friends, notifications, add to recipes."""
+import json
+import pytest
+
+from database import (
+	create_user,
+	create_recipe,
+	create_friend_request,
+	accept_friend_request,
+	create_recipe_share,
+	share_recipe_with_friends,
+	add_shared_recipe_to_user,
+)
+from database import Select
+
+
+# ————————————————————————————————— Fixtures ————————————————————————————————— #
+
+@pytest.fixture
+def sharer_id():
+	"""Create a user who will share a recipe."""
+	email = f"sharer_{id(object())}@test.com"
+	return create_user(email, "Recipe Sharer", "Pass123")
+
+
+@pytest.fixture
+def recipient_id():
+	"""Create a user who will receive a shared recipe."""
+	email = f"recipient_{id(object())}@test.com"
+	return create_user(email, "Recipe Recipient", "Pass456")
+
+
+@pytest.fixture
+def second_recipient_id():
+	"""Create a second recipient for multi-share tests."""
+	email = f"recipient2_{id(object())}@test.com"
+	return create_user(email, "Second Recipient", "Pass789")
+
+
+@pytest.fixture
+def shared_recipe(sharer_id):
+	"""Create a recipe owned by sharer."""
+	return create_recipe(
+		title="Shared Chocolate Cake",
+		Persons_id=sharer_id,
+		ingredients="2 cups flour\n1 cup sugar\n3 eggs",
+		steps="Mix ingredients\nBake at 350°F\nCool",
+		special_notes="Serves 8",
+		source_url="https://example.com/cake",
+		category="Desserts",
+	)
+
+
+@pytest.fixture
+def friends(sharer_id, recipient_id):
+	"""Make sharer and recipient friends."""
+	create_friend_request(sharer_id, recipient_id)
+	req = Select.get_pending_friend_requests_for_user(recipient_id)[0][0]
+	accept_friend_request(req.id, recipient_id)
+	return (sharer_id, recipient_id)
+
+
+@pytest.fixture
+def recipe_share(sharer_id, recipient_id, shared_recipe, friends):
+	"""Create a recipe share from sharer to recipient."""
+	return create_recipe_share(shared_recipe, sharer_id, recipient_id)
+
+
+# ————————————————————————————————— Database: create_recipe_share ———————————— #
+
+class TestCreateRecipeShare:
+	"""Tests for create_recipe_share database function."""
+
+	def test_create_recipe_share_success(self, sharer_id, recipient_id, shared_recipe, friends):
+		"""create_recipe_share creates a share and returns share id."""
+		share_id = create_recipe_share(shared_recipe, sharer_id, recipient_id)
+		assert share_id is not None
+
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+		share, recipe, sharer = shares[0]
+		assert share.id == share_id
+		assert recipe.id == shared_recipe
+		assert recipe.title == "Shared Chocolate Cake"
+		assert sharer.id == sharer_id
+
+	def test_create_recipe_share_self_raises(self, sharer_id, shared_recipe):
+		"""create_recipe_share raises when sharer equals recipient."""
+		with pytest.raises(ValueError, match="cannot share a recipe with yourself"):
+			create_recipe_share(shared_recipe, sharer_id, sharer_id)
+
+	def test_create_recipe_share_duplicate_raises(self, sharer_id, recipient_id, shared_recipe, friends):
+		"""create_recipe_share raises when already shared with that friend."""
+		create_recipe_share(shared_recipe, sharer_id, recipient_id)
+		with pytest.raises(ValueError, match="already shared"):
+			create_recipe_share(shared_recipe, sharer_id, recipient_id)
+
+	def test_create_recipe_share_nonexistent_recipe_raises(self, sharer_id, recipient_id, friends):
+		"""create_recipe_share raises when recipe does not exist or not owned by sharer."""
+		with pytest.raises(ValueError, match="Recipe not found"):
+			create_recipe_share(99999, sharer_id, recipient_id)
+
+
+# ————————————————————————————————— Database: share_recipe_with_friends —————— #
+
+class TestShareRecipeWithFriends:
+	"""Tests for share_recipe_with_friends database function."""
+
+	def test_share_with_multiple_friends(
+		self, sharer_id, recipient_id, second_recipient_id, shared_recipe
+	):
+		"""share_recipe_with_friends creates shares for each recipient."""
+		create_friend_request(sharer_id, recipient_id)
+		req1 = Select.get_pending_friend_requests_for_user(recipient_id)[0][0]
+		accept_friend_request(req1.id, recipient_id)
+
+		create_friend_request(sharer_id, second_recipient_id)
+		req2 = Select.get_pending_friend_requests_for_user(second_recipient_id)[0][0]
+		accept_friend_request(req2.id, second_recipient_id)
+
+		success_count, errors = share_recipe_with_friends(
+			shared_recipe, sharer_id, [recipient_id, second_recipient_id]
+		)
+		assert success_count == 2
+		assert len(errors) == 0
+
+		shares1 = Select.get_recipe_shares_for_recipient(recipient_id)
+		shares2 = Select.get_recipe_shares_for_recipient(second_recipient_id)
+		assert len(shares1) == 1
+		assert len(shares2) == 1
+
+	def test_share_with_friends_skips_self(self, sharer_id, recipient_id, shared_recipe, friends):
+		"""share_recipe_with_friends skips sharer in recipient list."""
+		success_count, errors = share_recipe_with_friends(
+			shared_recipe, sharer_id, [recipient_id, sharer_id]
+		)
+		assert success_count == 1
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+
+	def test_share_with_friends_handles_duplicate(
+		self, sharer_id, recipient_id, shared_recipe, friends
+	):
+		"""share_recipe_with_friends reports error for already-shared friend but succeeds for new."""
+		create_recipe_share(shared_recipe, sharer_id, recipient_id)
+
+		other_id = create_user(f"other_{id(object())}@test.com", "Other", "pass")
+		create_friend_request(sharer_id, other_id)
+		req = Select.get_pending_friend_requests_for_user(other_id)[0][0]
+		accept_friend_request(req.id, other_id)
+
+		success_count, errors = share_recipe_with_friends(
+			shared_recipe, sharer_id, [recipient_id, other_id]
+		)
+		assert success_count == 1
+		assert len(errors) >= 1
+		assert "already shared" in errors[0].lower()
+
+
+# ————————————————————————————————— Database: add_shared_recipe_to_user —————— #
+
+class TestAddSharedRecipeToUser:
+	"""Tests for add_shared_recipe_to_user database function."""
+
+	def test_add_shared_recipe_success(self, recipe_share, recipient_id, shared_recipe):
+		"""add_shared_recipe_to_user copies recipe to recipient and returns new recipe id."""
+		new_id = add_shared_recipe_to_user(recipe_share, recipient_id)
+		assert new_id is not None
+
+		recipe = Select.get_Recipe_by_id(new_id, recipient_id)
+		assert recipe is not None
+		assert recipe.title == "Shared Chocolate Cake"
+		assert "flour" in recipe.ingredients
+		assert "Mix ingredients" in recipe.steps
+		assert recipe.special_notes == "Serves 8"
+		assert recipe.source_url == "https://example.com/cake"
+		assert recipe.category == "Desserts"
+		assert new_id != shared_recipe
+
+	def test_add_shared_recipe_copies_images(
+		self, sharer_id, recipient_id, shared_recipe, friends
+	):
+		"""add_shared_recipe_to_user copies recipe images to the new recipe."""
+		from database import create_recipe_image
+		create_recipe_image(shared_recipe, "uploads/recipes/cake.jpg")
+		share_id = create_recipe_share(shared_recipe, sharer_id, recipient_id)
+
+		new_id = add_shared_recipe_to_user(share_id, recipient_id)
+		images = Select.get_recipe_images(new_id)
+		assert len(images) == 1
+		assert images[0].file_path == "uploads/recipes/cake.jpg"
+
+	def test_add_shared_recipe_wrong_recipient_returns_none(
+		self, recipe_share, recipient_id, sharer_id
+	):
+		"""add_shared_recipe_to_user returns None when recipient doesn't match."""
+		other_id = create_user(f"other_{id(object())}@test.com", "Other", "pass")
+		result = add_shared_recipe_to_user(recipe_share, other_id)
+		assert result is None
+
+		# Recipient's recipes unchanged
+		recipes = Select.get_Recipes_by_Persons_id(recipient_id)
+		titles = [r.title for r in recipes]
+		assert "Shared Chocolate Cake" not in titles
+
+	def test_add_shared_recipe_nonexistent_share_returns_none(self, recipient_id):
+		"""add_shared_recipe_to_user returns None for invalid share id."""
+		result = add_shared_recipe_to_user(99999, recipient_id)
+		assert result is None
+
+
+# ————————————————————————————————— Database: Select —————————————————————————— #
+
+class TestRecipeShareSelect:
+	"""Tests for recipe share Select functions."""
+
+	def test_get_recipe_shares_for_recipient_empty(self, recipient_id):
+		"""get_recipe_shares_for_recipient returns empty when no shares."""
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert shares == []
+
+	def test_get_recipe_shares_for_recipient_returns_shares(
+		self, recipe_share, recipient_id, shared_recipe, sharer_id
+	):
+		"""get_recipe_shares_for_recipient returns (share, recipe, sharer) tuples."""
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+		share, recipe, sharer = shares[0]
+		assert share.id == recipe_share
+		assert recipe.id == shared_recipe
+		assert sharer.id == sharer_id
+		assert sharer.name == "Recipe Sharer"
+
+	def test_get_recipe_share_by_id_success(self, recipe_share, recipient_id):
+		"""get_recipe_share_by_id returns share when recipient matches."""
+		row = Select.get_recipe_share_by_id(recipe_share, recipient_id)
+		assert row is not None
+		share, recipe, sharer = row
+		assert share.id == recipe_share
+		assert recipe.title == "Shared Chocolate Cake"
+
+	def test_get_recipe_share_by_id_wrong_recipient_returns_none(
+		self, recipe_share, recipient_id, sharer_id
+	):
+		"""get_recipe_share_by_id returns None when recipient doesn't match."""
+		row = Select.get_recipe_share_by_id(recipe_share, sharer_id)
+		assert row is None
+
+	def test_get_recipe_share_by_id_nonexistent_returns_none(self, recipient_id):
+		"""get_recipe_share_by_id returns None for invalid share id."""
+		row = Select.get_recipe_share_by_id(99999, recipient_id)
+		assert row is None
+
+
+# ————————————————————————————————— Routes: share recipe ——————————————————— #
+
+class TestShareRecipeRoute:
+	"""Tests for POST /Recipe/<id>/share."""
+
+	def test_share_recipe_requires_login(self, client, sharer_id, shared_recipe):
+		"""POST /Recipe/<id>/share returns 401/302 when not authenticated."""
+		resp = client.post(
+			f"/Recipe/{shared_recipe}/share",
+			data=json.dumps({"recipient_ids": [1]}),
+			content_type="application/json",
+			follow_redirects=False,
+		)
+		assert resp.status_code in (302, 401)
+
+	def test_share_recipe_success(self, logged_in_client, sharer_id, recipient_id, shared_recipe, friends):
+		"""POST /Recipe/<id>/share with valid friend ids returns success."""
+		client, user_id = logged_in_client
+		# logged_in_client uses different user - we need sharer to be logged in
+		# So we need: sharer = logged in user, recipient = friend
+		# Create setup: user_id (logged in) = sharer, recipient_id = friend
+		create_friend_request(user_id, recipient_id)
+		req = Select.get_pending_friend_requests_for_user(recipient_id)[0][0]
+		accept_friend_request(req.id, recipient_id)
+
+		rid = create_recipe("To Share", user_id, ingredients="flour")
+		resp = client.post(
+			f"/Recipe/{rid}/share",
+			data=json.dumps({"recipient_ids": [recipient_id]}),
+			content_type="application/json",
+			follow_redirects=False,
+		)
+		assert resp.status_code == 200
+		data = resp.get_json()
+		assert data["success"] is True
+		assert data["shared_count"] == 1
+
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+		assert shares[0][1].title == "To Share"
+
+	def test_share_recipe_empty_recipients_returns_400(self, logged_in_client):
+		"""POST /Recipe/<id>/share with no recipients returns 400."""
+		client, user_id = logged_in_client
+		rid = create_recipe("Empty Share Test", user_id)
+		resp = client.post(
+			f"/Recipe/{rid}/share",
+			data=json.dumps({"recipient_ids": []}),
+			content_type="application/json",
+			follow_redirects=False,
+		)
+		assert resp.status_code == 400
+		data = resp.get_json()
+		assert data["success"] is False
+
+	def test_share_recipe_404_for_nonexistent(self, logged_in_client):
+		"""POST /Recipe/99999/share returns 404."""
+		client, _ = logged_in_client
+		resp = client.post(
+			"/Recipe/99999/share",
+			data=json.dumps({"recipient_ids": [1]}),
+			content_type="application/json",
+			follow_redirects=False,
+		)
+		assert resp.status_code == 404
+
+	def test_share_recipe_404_for_other_user_recipe(
+		self, logged_in_client, sharer_id, shared_recipe, recipient_id, friends
+	):
+		"""POST /Recipe/<id>/share returns 404 when recipe belongs to another user."""
+		client, _ = logged_in_client
+		# shared_recipe belongs to sharer_id, logged_in_client is different user
+		resp = client.post(
+			f"/Recipe/{shared_recipe}/share",
+			data=json.dumps({"recipient_ids": [recipient_id]}),
+			content_type="application/json",
+			follow_redirects=False,
+		)
+		assert resp.status_code == 404
+
+
+# ————————————————————————————————— Routes: shared recipe detail ———————————— #
+
+class TestSharedRecipeDetailRoute:
+	"""Tests for GET and POST /Recipe/Shared/<share_id>."""
+
+	def test_shared_recipe_requires_login(self, client, recipe_share):
+		"""GET /Recipe/Shared/<id> redirects when not authenticated."""
+		resp = client.get(f"/Recipe/Shared/{recipe_share}", follow_redirects=False)
+		assert resp.status_code in (302, 401)
+
+	def test_shared_recipe_get_success(self, logged_in_client, recipe_share, recipient_id):
+		"""GET /Recipe/Shared/<id> shows recipe when recipient is logged in."""
+		client, user_id = logged_in_client
+		# We need recipient to be the logged-in user
+		# logged_in_client creates its own user. We need to log in as recipient.
+		# Create recipient and log in as them
+		email = f"shared_recipient_{id(object())}@test.com"
+		rec_id = create_user(email, "Shared Recipient", "Pass123")
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		# Create share to this recipient
+		sharer_id = create_user(f"shared_sharer_{id(object())}@test.com", "Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("Shared View Test", sharer_id, ingredients="eggs")
+		share_id = create_recipe_share(rid, sharer_id, rec_id)
+
+		resp = client.get(f"/Recipe/Shared/{share_id}", follow_redirects=True)
+		assert resp.status_code == 200
+		assert b"Shared View Test" in resp.data
+		assert b"eggs" in resp.data
+		assert b"Add to my recipes" in resp.data
+		assert b"Exit without adding" in resp.data
+
+	def test_shared_recipe_post_add(self, logged_in_client, recipe_share, recipient_id, shared_recipe):
+		"""POST /Recipe/Shared/<id> with action=add copies recipe to user."""
+		email = f"add_recipient_{id(object())}@test.com"
+		rec_id = create_user(email, "Add Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		sharer_id = create_user(f"add_sharer_{id(object())}@test.com", "Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("To Add Recipe", sharer_id, ingredients="flour\nsugar")
+		share_id = create_recipe_share(rid, sharer_id, rec_id)
+
+		resp = client.post(
+			f"/Recipe/Shared/{share_id}",
+			data={"action": "add"},
+			content_type="application/x-www-form-urlencoded",
+			follow_redirects=True,
+		)
+		assert resp.status_code == 200
+
+		recipes = Select.get_Recipes_by_Persons_id(rec_id)
+		titles = [r.title for r in recipes]
+		assert "To Add Recipe" in titles
+
+	def test_shared_recipe_404_for_wrong_recipient(
+		self, logged_in_client, recipe_share, recipient_id, sharer_id
+	):
+		"""GET /Recipe/Shared/<id> returns 404 when current user is not the recipient."""
+		client, _ = logged_in_client
+		# logged_in_client is different from recipient_id
+		resp = client.get(f"/Recipe/Shared/{recipe_share}", follow_redirects=False)
+		assert resp.status_code == 404
+
+	def test_shared_recipe_404_for_nonexistent(self, logged_in_client):
+		"""GET /Recipe/Shared/99999 returns 404."""
+		client, _ = logged_in_client
+		resp = client.get("/Recipe/Shared/99999", follow_redirects=False)
+		assert resp.status_code == 404
+
+
+# ————————————————————————————————— Routes: notifications ——————————————————— #
+
+class TestNotificationsRecipeShares:
+	"""Tests that notifications page includes recipe shares."""
+
+	def test_notifications_shows_recipe_shares(self, logged_in_client, recipe_share, recipient_id):
+		"""GET /Friends/Notifications shows shared recipes when recipient is logged in."""
+		email = f"notif_recipient_{id(object())}@test.com"
+		rec_id = create_user(email, "Notif Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		sharer_id = create_user(f"notif_sharer_{id(object())}@test.com", "Notif Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("Notif Shared Recipe", sharer_id)
+		create_recipe_share(rid, sharer_id, rec_id)
+
+		resp = client.get("/Friends/Notifications", follow_redirects=True)
+		assert resp.status_code == 200
+		assert b"Shared recipes" in resp.data
+		assert b"Notif Shared Recipe" in resp.data
+		assert b"View recipe" in resp.data

--- a/tests/test_recipe_sharing.py
+++ b/tests/test_recipe_sharing.py
@@ -10,6 +10,7 @@ from database import (
 	create_recipe_share,
 	share_recipe_with_friends,
 	add_shared_recipe_to_user,
+	dismiss_notification,
 )
 from database import Select
 
@@ -251,6 +252,51 @@ class TestRecipeShareSelect:
 		row = Select.get_recipe_share_by_id(99999, recipient_id)
 		assert row is None
 
+	def test_get_recipe_shares_excludes_dismissed(self, recipe_share, recipient_id):
+		"""get_recipe_shares_for_recipient excludes dismissed shares."""
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+		dismiss_notification(recipient_id, "recipe_share", recipe_share)
+		shares_after = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares_after) == 0
+
+
+# ————————————————————————————————— Database: dismiss_notification ——————————— #
+
+class TestDismissNotification:
+	"""Tests for dismiss_notification database function."""
+
+	def test_dismiss_notification_recipe_share(self, recipe_share, recipient_id):
+		"""dismiss_notification records recipe_share dismissal."""
+		result = dismiss_notification(recipient_id, "recipe_share", recipe_share)
+		assert result is True
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 0
+
+	def test_dismiss_notification_friend_request(self, sharer_id, recipient_id):
+		"""dismiss_notification records friend_request dismissal."""
+		create_friend_request(sharer_id, recipient_id)
+		req = Select.get_pending_friend_requests_for_user(recipient_id)[0][0]
+		result = dismiss_notification(recipient_id, "friend_request", req.id)
+		assert result is True
+		pending = Select.get_pending_friend_requests_for_user(recipient_id)
+		assert len(pending) == 0
+
+	def test_dismiss_notification_invalid_type_returns_false(self, recipe_share, recipient_id):
+		"""dismiss_notification returns False for invalid notification_type."""
+		result = dismiss_notification(recipient_id, "invalid_type", recipe_share)
+		assert result is False
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 1
+
+	def test_dismiss_notification_idempotent(self, recipe_share, recipient_id):
+		"""dismiss_notification is idempotent - calling twice still works."""
+		dismiss_notification(recipient_id, "recipe_share", recipe_share)
+		result = dismiss_notification(recipient_id, "recipe_share", recipe_share)
+		assert result is True
+		shares = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares) == 0
+
 
 # ————————————————————————————————— Routes: share recipe ——————————————————— #
 
@@ -368,6 +414,31 @@ class TestSharedRecipeDetailRoute:
 		assert b"eggs" in resp.data
 		assert b"Add to my recipes" in resp.data
 		assert b"Exit without adding" in resp.data
+		assert b"Shared by" in resp.data
+		assert b"Sharer" in resp.data
+
+	def test_shared_recipe_viewing_auto_dismisses_notification(self, logged_in_client, recipe_share, recipient_id):
+		"""GET /Recipe/Shared/<id> auto-dismisses the notification so it no longer appears."""
+		email = f"auto_dismiss_{id(object())}@test.com"
+		rec_id = create_user(email, "Auto Dismiss Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		sharer_id = create_user(f"auto_dismiss_sharer_{id(object())}@test.com", "Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("Auto Dismiss Recipe", sharer_id)
+		share_id = create_recipe_share(rid, sharer_id, rec_id)
+
+		shares_before = Select.get_recipe_shares_for_recipient(rec_id)
+		assert len(shares_before) == 1
+
+		client.get(f"/Recipe/Shared/{share_id}", follow_redirects=True)
+
+		shares_after = Select.get_recipe_shares_for_recipient(rec_id)
+		assert len(shares_after) == 0
 
 	def test_shared_recipe_post_add(self, logged_in_client, recipe_share, recipient_id, shared_recipe):
 		"""POST /Recipe/Shared/<id> with action=add copies recipe to user."""
@@ -412,10 +483,126 @@ class TestSharedRecipeDetailRoute:
 		assert resp.status_code == 404
 
 
+# ————————————————————————————————— Routes: dismiss notification ———————————— #
+
+class TestDismissNotificationRoute:
+	"""Tests for POST /Notifications/Dismiss."""
+
+	def test_dismiss_route_requires_login(self, client, recipe_share):
+		"""POST /Notifications/Dismiss redirects when not authenticated."""
+		resp = client.post(
+			"/Notifications/Dismiss",
+			data={"notification_type": "recipe_share", "notification_id": recipe_share},
+			content_type="application/x-www-form-urlencoded",
+			follow_redirects=False,
+		)
+		assert resp.status_code in (302, 401)
+
+	def test_dismiss_route_recipe_share(self, logged_in_client, recipe_share, recipient_id):
+		"""POST /Notifications/Dismiss with recipe_share dismisses and redirects."""
+		email = f"dismiss_route_{id(object())}@test.com"
+		rec_id = create_user(email, "Dismiss Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		sharer_id = create_user(f"dismiss_sharer_{id(object())}@test.com", "Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("Dismiss Route Recipe", sharer_id)
+		share_id = create_recipe_share(rid, sharer_id, rec_id)
+
+		shares_before = Select.get_recipe_shares_for_recipient(rec_id)
+		assert len(shares_before) == 1
+
+		resp = client.post(
+			"/Notifications/Dismiss",
+			data={"notification_type": "recipe_share", "notification_id": share_id},
+			content_type="application/x-www-form-urlencoded",
+			follow_redirects=True,
+		)
+		assert resp.status_code == 200
+		shares_after = Select.get_recipe_shares_for_recipient(rec_id)
+		assert len(shares_after) == 0
+
+	def test_dismiss_route_friend_request(self, logged_in_client, sharer_id, recipient_id):
+		"""POST /Notifications/Dismiss with friend_request dismisses and redirects."""
+		create_friend_request(sharer_id, recipient_id)
+		req = Select.get_pending_friend_requests_for_user(recipient_id)[0][0]
+
+		email = f"dismiss_fr_{id(object())}@test.com"
+		rec_id = create_user(email, "Dismiss FR Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		requester_id = create_user(f"dismiss_requester_{id(object())}@test.com", "Requester", "pass")
+		create_friend_request(requester_id, rec_id)
+		req_id = Select.get_pending_friend_requests_for_user(rec_id)[0][0].id
+
+		pending_before = Select.get_pending_friend_requests_for_user(rec_id)
+		assert len(pending_before) == 1
+
+		resp = client.post(
+			"/Notifications/Dismiss",
+			data={"notification_type": "friend_request", "notification_id": req_id},
+			content_type="application/x-www-form-urlencoded",
+			follow_redirects=True,
+		)
+		assert resp.status_code == 200
+		pending_after = Select.get_pending_friend_requests_for_user(rec_id)
+		assert len(pending_after) == 0
+
+	def test_dismiss_route_redirects_to_notifications(self, logged_in_client, recipe_share, recipient_id):
+		"""POST /Notifications/Dismiss redirects to notifications page."""
+		email = f"dismiss_redirect_{id(object())}@test.com"
+		rec_id = create_user(email, "Redirect Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+
+		sharer_id = create_user(f"dismiss_redirect_sharer_{id(object())}@test.com", "Sharer", "pass")
+		create_friend_request(sharer_id, rec_id)
+		req = Select.get_pending_friend_requests_for_user(rec_id)[0][0]
+		accept_friend_request(req.id, rec_id)
+		rid = create_recipe("Redirect Recipe", sharer_id)
+		share_id = create_recipe_share(rid, sharer_id, rec_id)
+
+		resp = client.post(
+			"/Notifications/Dismiss",
+			data={"notification_type": "recipe_share", "notification_id": share_id},
+			content_type="application/x-www-form-urlencoded",
+			follow_redirects=False,
+		)
+		assert resp.status_code == 302
+		assert "Notifications" in resp.headers.get("Location", "")
+
+
 # ————————————————————————————————— Routes: notifications ——————————————————— #
 
 class TestNotificationsRecipeShares:
 	"""Tests that notifications page includes recipe shares."""
+
+	def test_dismiss_recipe_share_hides_from_notifications(self, recipe_share, recipient_id):
+		"""dismiss_notification hides recipe share from get_recipe_shares_for_recipient."""
+		shares_before = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares_before) == 1
+
+		dismiss_notification(recipient_id, "recipe_share", recipe_share)
+		shares_after = Select.get_recipe_shares_for_recipient(recipient_id)
+		assert len(shares_after) == 0
+
+	def test_dismiss_friend_request_hides_from_pending(self, sharer_id, recipient_id, shared_recipe):
+		"""dismiss_notification hides friend request from get_pending_friend_requests_for_user."""
+		create_friend_request(sharer_id, recipient_id)
+		pending_before = Select.get_pending_friend_requests_for_user(recipient_id)
+		assert len(pending_before) == 1
+		req_id = pending_before[0][0].id
+
+		dismiss_notification(recipient_id, "friend_request", req_id)
+		pending_after = Select.get_pending_friend_requests_for_user(recipient_id)
+		assert len(pending_after) == 0
 
 	def test_notifications_shows_recipe_shares(self, logged_in_client, recipe_share, recipient_id):
 		"""GET /Friends/Notifications shows shared recipes when recipient is logged in."""
@@ -437,3 +624,20 @@ class TestNotificationsRecipeShares:
 		assert b"Shared recipes" in resp.data
 		assert b"Notif Shared Recipe" in resp.data
 		assert b"View recipe" in resp.data
+		assert b"notification-dismiss" in resp.data or b"aria-label=\"Dismiss\"" in resp.data
+
+	def test_notifications_shows_dismiss_button_for_friend_requests(self, logged_in_client, sharer_id, recipient_id):
+		"""GET /Friends/Notifications shows dismiss button for friend requests."""
+		create_friend_request(sharer_id, recipient_id)
+		email = f"dismiss_btn_{id(object())}@test.com"
+		rec_id = create_user(email, "Dismiss Btn Recipient", "Pass123")
+		client, _ = logged_in_client
+		client.post("/Logout", follow_redirects=True)
+		client.post("/Login", data={"email": email, "pass": "Pass123"}, follow_redirects=True)
+		requester_id = create_user(f"dismiss_btn_req_{id(object())}@test.com", "Requester", "pass")
+		create_friend_request(requester_id, rec_id)
+
+		resp = client.get("/Friends/Notifications", follow_redirects=True)
+		assert resp.status_code == 200
+		assert b"Friend requests" in resp.data
+		assert b"aria-label=\"Dismiss\"" in resp.data


### PR DESCRIPTION
## Share Recipe with Friends

### Summary
Adds recipe sharing between friends: share a recipe, receive it in notifications, and choose to import or ignore.

### Changes
- **Share recipes** — Share recipes with friends from the recipe view
- **Shared recipe view** — New `SharedRecipe.j2` template with import/ignore actions
- **Notifications** — Dismiss notifications; shared recipes appear in the notifications feed
- **Unit tests** — Tests for sharing, importing, and ignoring shared recipes

### Files
- `GroceryGuru.py` — Share/import/ignore routes and notification handling
- `Select.py` — DB queries for shared recipes
- `SharedRecipe.j2` — Shared recipe UI
- `Notifications.j2` — Dismiss support
- `test_recipe_sharing.py` — Sharing tests